### PR TITLE
Bug with HTML Webpack Plugin v3.0.4

### DIFF
--- a/lib/HtmlStringReplace.js
+++ b/lib/HtmlStringReplace.js
@@ -33,8 +33,6 @@ HtmlStringReplace.prototype.apply = function (compiler) {
         if (that.enable) {
             htmlPluginData.html = that.replaceString(htmlPluginData.html, htmlPluginData.plugin.options);
         }
-
-        callback(null, htmlPluginData);
     });
 };
 


### PR DESCRIPTION
It is not necessary to use a callback when html data is replaced. In fact, it doesn't work because they removed that attribute. So the fix is simple, just remove that line.
Reference: https://github.com/jantimon/html-webpack-plugin/blob/master/index.js#L193